### PR TITLE
Move activity-indicator to dependencies and update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@internetarchive/histogram-date-range",
-  "version": "0.0.9-alpha",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/histogram-date-range",
-      "version": "0.0.9-alpha",
+      "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@internetarchive/ia-activity-indicator": "^0.0.2",
         "dayjs": "^1.9.7",
         "lit": "^2.0.0-rc.2"
       },
       "devDependencies": {
-        "@internetarchive/ia-activity-indicator": "^0.0.1",
         "@open-wc/eslint-config": "^4.2.0",
         "@open-wc/testing": "^2.0.0",
         "@typescript-eslint/eslint-plugin": "^2.20.0",
@@ -112,19 +112,17 @@
       }
     },
     "node_modules/@internetarchive/ia-activity-indicator": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.1.tgz",
-      "integrity": "sha512-+l7p1v4QuojgvQwFaIVnHOq9WfeARv9+jBbY/xmj6S8v1QTxW8+OwOkx8GaNuLN57e09uYTlo+EPP7BScOc+tA==",
-      "dev": true,
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.2.tgz",
+      "integrity": "sha512-PHSTn8LJyozrVcMj6eMQKqBJD+029YhxffbW+oLKGAfmS5tAkpl2LfHlFcLCozT5e9e+KECCq2m2UeUyPYPjcw==",
       "dependencies": {
-        "lit-element": "^2.2.1",
-        "lit-html": "^1.1.2"
+        "lit": "^2.0.2"
       }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
-      "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
+      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -602,9 +600,9 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.0",
@@ -4968,13 +4966,13 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.2.tgz",
-      "integrity": "sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
+      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-element": "^3.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       }
     },
     "node_modules/lit-element": {
@@ -4993,20 +4991,20 @@
       "dev": true
     },
     "node_modules/lit/node_modules/lit-element": {
-      "version": "3.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.2.tgz",
-      "integrity": "sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
       "dependencies": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
       }
     },
     "node_modules/lit/node_modules/lit-html": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.3.tgz",
-      "integrity": "sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+      "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
       "dependencies": {
-        "@types/trusted-types": "^1.0.1"
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/load-json-file": {
@@ -7990,19 +7988,17 @@
       }
     },
     "@internetarchive/ia-activity-indicator": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.1.tgz",
-      "integrity": "sha512-+l7p1v4QuojgvQwFaIVnHOq9WfeARv9+jBbY/xmj6S8v1QTxW8+OwOkx8GaNuLN57e09uYTlo+EPP7BScOc+tA==",
-      "dev": true,
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-activity-indicator/-/ia-activity-indicator-0.0.2.tgz",
+      "integrity": "sha512-PHSTn8LJyozrVcMj6eMQKqBJD+029YhxffbW+oLKGAfmS5tAkpl2LfHlFcLCozT5e9e+KECCq2m2UeUyPYPjcw==",
       "requires": {
-        "lit-element": "^2.2.1",
-        "lit-html": "^1.1.2"
+        "lit": "^2.0.2"
       }
     },
     "@lit/reactive-element": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz",
-      "integrity": "sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
+      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -8463,9 +8459,9 @@
       "dev": true
     },
     "@types/trusted-types": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-1.0.6.tgz",
-      "integrity": "sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
     "@types/ws": {
       "version": "7.4.0",
@@ -12017,30 +12013,30 @@
       }
     },
     "lit": {
-      "version": "2.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.0-rc.2.tgz",
-      "integrity": "sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
+      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0-rc.2",
-        "lit-element": "^3.0.0-rc.2",
-        "lit-html": "^2.0.0-rc.3"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       },
       "dependencies": {
         "lit-element": {
-          "version": "3.0.0-rc.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.0-rc.2.tgz",
-          "integrity": "sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+          "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
           "requires": {
-            "@lit/reactive-element": "^1.0.0-rc.2",
-            "lit-html": "^2.0.0-rc.3"
+            "@lit/reactive-element": "^1.3.0",
+            "lit-html": "^2.2.0"
           }
         },
         "lit-html": {
-          "version": "2.0.0-rc.3",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.0-rc.3.tgz",
-          "integrity": "sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+          "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
           "requires": {
-            "@types/trusted-types": "^1.0.1"
+            "@types/trusted-types": "^2.0.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "test:watch": "tsc && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wtr --watch\""
   },
   "dependencies": {
+    "@internetarchive/ia-activity-indicator": "^0.0.2",
     "dayjs": "^1.9.7",
     "lit": "^2.0.0-rc.2"
   },
   "devDependencies": {
-    "@internetarchive/ia-activity-indicator": "^0.0.1",
     "@open-wc/eslint-config": "^4.2.0",
     "@open-wc/testing": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^2.20.0",


### PR DESCRIPTION
Since the activity-indicator is a [dependency](https://github.com/internetarchive/iaux-histogram-date-range/blob/main/src/histogram-date-range.ts#L14) of the component itself, it needs to be a dependency, not `devDependency` so consumers know to load it.