### PR TITLE
WEBDEV-5281 Fix handle drag offsets

### DIFF
--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -310,7 +310,8 @@ export class HistogramDateRange extends LitElement {
    * @param e PointerEvent from the slider being moved
    */
   private move = (e: PointerEvent): void => {
-    const newX = e.offsetX - this._dragOffset;
+    const histogramClientX = this.getBoundingClientRect().x;
+    const newX = e.clientX - histogramClientX - this._dragOffset;
     const slider = this._currentSlider as SVGRectElement;
     if ((slider.id as SliderId) === 'slider-min') {
       this.minSelectedDate = this.translatePositionToDate(
@@ -419,15 +420,8 @@ export class HistogramDateRange extends LitElement {
       (this._currentSlider.id as SliderId) === 'slider-min'
         ? this.minSliderX
         : this.maxSliderX;
-    this._dragOffset = e.offsetX - sliderX;
-    // work around Firefox issue where e.offsetX seems to be not based on current
-    // element but on background element
-    if (
-      this._dragOffset > this.sliderWidth ||
-      this._dragOffset < -this.sliderWidth
-    ) {
-      this._dragOffset = 0;
-    }
+    const histogramClientX = this.getBoundingClientRect().x;
+    this._dragOffset = e.clientX - histogramClientX - sliderX;
   }
 
   /**

--- a/test/histogram-date-range.test.ts
+++ b/test/histogram-date-range.test.ts
@@ -45,9 +45,9 @@ async function createCustomElementInHTMLContainer(): Promise<HistogramDateRange>
 describe('HistogramDateRange', () => {
   it('shows scaled histogram bars when provided with data', async () => {
     const el = await createCustomElementInHTMLContainer();
-    const bars = (el.shadowRoot?.querySelectorAll(
+    const bars = el.shadowRoot?.querySelectorAll(
       '.bar'
-    ) as unknown) as SVGRectElement[];
+    ) as unknown as SVGRectElement[];
     const heights = Array.from(bars).map(b => b.height.baseVal.value);
 
     expect(heights).to.eql([38, 7, 50]);
@@ -171,7 +171,7 @@ describe('HistogramDateRange', () => {
     expect(classList.contains('dragging')).to.be.true;
 
     // slide to right
-    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 70 }));
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 60 }));
     await el.updateComplete;
 
     // slider has moved
@@ -197,7 +197,7 @@ describe('HistogramDateRange', () => {
 
     // slide to left
     maxSlider.dispatchEvent(new PointerEvent('pointerdown', { clientX: 195 }));
-    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 160 }));
+    window.dispatchEvent(new PointerEvent('pointermove', { clientX: 165 }));
     await el.updateComplete;
 
     // slider has moved
@@ -276,9 +276,9 @@ describe('HistogramDateRange', () => {
     // include a number which will require commas (1,000,000)
     el.bins = [1000000, 1, 100];
     await aTimeout(10);
-    const bars = (el.shadowRoot?.querySelectorAll(
+    const bars = el.shadowRoot?.querySelectorAll(
       '.bar'
-    ) as unknown) as SVGRectElement[];
+    ) as unknown as SVGRectElement[];
     const tooltip = el.shadowRoot?.querySelector('#tooltip') as HTMLDivElement;
     expect(tooltip.innerText).to.eq('');
 
@@ -304,9 +304,9 @@ describe('HistogramDateRange', () => {
 
   it('does not show tooltip while dragging', async () => {
     const el = await createCustomElementInHTMLContainer();
-    const bars = (el.shadowRoot?.querySelectorAll(
+    const bars = el.shadowRoot?.querySelectorAll(
       '.bar'
-    ) as unknown) as SVGRectElement[];
+    ) as unknown as SVGRectElement[];
     const tooltip = el.shadowRoot?.querySelector('#tooltip') as HTMLDivElement;
     expect(tooltip.innerText).to.eq('');
     const minSlider = el.shadowRoot?.querySelector('#slider-min') as SVGElement;
@@ -492,9 +492,9 @@ describe('HistogramDateRange', () => {
         </histogram-date-range>
       `
     );
-    const bars = (el.shadowRoot?.querySelectorAll(
+    const bars = el.shadowRoot?.querySelectorAll(
       '.bar'
-    ) as unknown) as SVGRectElement[];
+    ) as unknown as SVGRectElement[];
     const heights = Array.from(bars).map(b => b.height.baseVal.value);
     expect(heights).to.eql([157]);
   });
@@ -506,9 +506,9 @@ describe('HistogramDateRange', () => {
         </histogram-date-range>
       `
     );
-    const bars = (el.shadowRoot?.querySelectorAll(
+    const bars = el.shadowRoot?.querySelectorAll(
       '.bar'
-    ) as unknown) as SVGRectElement[];
+    ) as unknown as SVGRectElement[];
     const heights = Array.from(bars).map(b => b.height.baseVal.value);
     expect(heights).to.eql([37, 40, 38, 38, 37, 36]);
   });


### PR DESCRIPTION
When dragging the min/max date handles on the beta search page, the handle position appears incorrectly offset from the pointer position. This seems to arise because the `offsetX` property of the handle svg's pointer events includes a wider left offset than expected (which, somewhat strangely, isn't the case on the legacy search page).

This PR works around the unusual `offsetX` behavior by using the mouse event's `clientX` instead, and explicitly subtracting off the histogram's own client left offset. This should be a more watertight solution, as the behavior of `clientX` and `getBoundingClientRect` are both strictly relative to the viewport and not the styles/surrounding context of the event target.