### PR TITLE
WEBDEV-5346 Add a slot beside the inputs where buttons or other content can be inserted

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ npm i @internetarchive/histogram-date-range
 ></histogram-date-range>
 ```
 
+A slot named `inputs-right-side` is available for inserting elements to the right
+of the min/max date input fields, e.g.:
+
+```html
+<histogram-date-range>
+  <button slot="inputs-right-side">Apply</button>
+</histogram-date-range>
+```
+
 ## Linting with ESLint, Prettier, and Types
 
 To scan the project for linting errors, run

--- a/docs/dist/src/histogram-date-range.js
+++ b/docs/dist/src/histogram-date-range.js
@@ -36,6 +36,7 @@ const selectedRangeColor = css`var(--histogramDateRangeSelectedRangeColor, #DBE0
 const barIncludedFill = css`var(--histogramDateRangeBarIncludedFill, #2C2C2C)`;
 const activityIndicatorColor = css`var(--histogramDateRangeActivityIndicator, #2C2C2C)`;
 const barExcludedFill = css`var(--histogramDateRangeBarExcludedFill, #CCCCCC)`;
+const inputRowMargin = css`var(--histogramDateRangeInputRowMargin, 0)`;
 const inputBorder = css`var(--histogramDateRangeInputBorder, 0.5px solid #2C2C2C)`;
 const inputWidth = css`var(--histogramDateRangeInputWidth, 35px)`;
 const inputFontSize = css`var(--histogramDateRangeInputFontSize, 1.2rem)`;
@@ -618,6 +619,7 @@ HistogramDateRange.styles = css`
     #inputs {
       display: flex;
       justify-content: center;
+      margin: ${inputRowMargin};
     }
     #inputs .dash {
       position: relative;

--- a/docs/dist/src/histogram-date-range.js
+++ b/docs/dist/src/histogram-date-range.js
@@ -529,6 +529,7 @@ export let HistogramDateRange = class extends LitElement {
             ${this.minLabelTemplate} ${this.minInputTemplate}
             <div class="dash">-</div>
             ${this.maxLabelTemplate} ${this.maxInputTemplate}
+            <slot name="inputs-right-side"></slot>
           </div>
         </div>
       </div>
@@ -621,6 +622,7 @@ HistogramDateRange.styles = css`
     #inputs .dash {
       position: relative;
       bottom: -1px;
+      align-self: center; /* Otherwise the dash sticks to the top while the inputs grow */
     }
     input {
       width: ${inputWidth};

--- a/docs/dist/src/histogram-date-range.js
+++ b/docs/dist/src/histogram-date-range.js
@@ -60,6 +60,7 @@ export let HistogramDateRange = class extends LitElement {
     this.maxDate = "";
     this.disabled = false;
     this.bins = [];
+    this.updateWhileFocused = false;
     this._tooltipOffset = 0;
     this._tooltipVisible = false;
     this._isDragging = false;
@@ -288,6 +289,11 @@ export let HistogramDateRange = class extends LitElement {
   clamp(x, minValue, maxValue) {
     return Math.min(Math.max(x, minValue), maxValue);
   }
+  handleInputFocus() {
+    if (!this.updateWhileFocused) {
+      this.cancelPendingUpdateEvent();
+    }
+  }
   handleMinDateInput(e) {
     const target = e.currentTarget;
     if (target.value !== this.minSelectedDate) {
@@ -441,7 +447,7 @@ export let HistogramDateRange = class extends LitElement {
         id="date-min"
         placeholder="${this.dateFormat}"
         type="text"
-        @focus="${this.cancelPendingUpdateEvent}"
+        @focus="${this.handleInputFocus}"
         @blur="${this.handleMinDateInput}"
         @keyup="${this.handleKeyUp}"
         .value="${live(this.minSelectedDate)}"
@@ -455,7 +461,7 @@ export let HistogramDateRange = class extends LitElement {
         id="date-max"
         placeholder="${this.dateFormat}"
         type="text"
-        @focus="${this.cancelPendingUpdateEvent}"
+        @focus="${this.handleInputFocus}"
         @blur="${this.handleMaxDateInput}"
         @keyup="${this.handleKeyUp}"
         .value="${live(this.maxSelectedDate)}"
@@ -685,6 +691,9 @@ __decorate([
 __decorate([
   property({type: Object})
 ], HistogramDateRange.prototype, "bins", 2);
+__decorate([
+  property({type: Boolean})
+], HistogramDateRange.prototype, "updateWhileFocused", 2);
 __decorate([
   state()
 ], HistogramDateRange.prototype, "_tooltipOffset", 2);

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -85,6 +85,8 @@ export class HistogramDateRange extends LitElement {
   @property({ type: String }) maxDate = '';
   @property({ type: Boolean }) disabled = false;
   @property({ type: Object }) bins: number[] = [];
+  /** If true, update events will not be canceled by the date inputs receiving focus */
+  @property({ type: Boolean }) updateWhileFocused = false;
 
   // internal reactive properties not exposed as attributes
   @state() private _tooltipOffset = 0;
@@ -466,6 +468,12 @@ export class HistogramDateRange extends LitElement {
     return Math.min(Math.max(x, minValue), maxValue);
   }
 
+  private handleInputFocus(): void {
+    if (!this.updateWhileFocused) {
+      this.cancelPendingUpdateEvent();
+    }
+  }
+
   private handleMinDateInput(e: Event): void {
     const target = e.currentTarget as HTMLInputElement;
     if (target.value !== this.minSelectedDate) {
@@ -686,7 +694,7 @@ export class HistogramDateRange extends LitElement {
         id="date-min"
         placeholder="${this.dateFormat}"
         type="text"
-        @focus="${this.cancelPendingUpdateEvent}"
+        @focus="${this.handleInputFocus}"
         @blur="${this.handleMinDateInput}"
         @keyup="${this.handleKeyUp}"
         .value="${live(this.minSelectedDate)}"
@@ -701,7 +709,7 @@ export class HistogramDateRange extends LitElement {
         id="date-max"
         placeholder="${this.dateFormat}"
         type="text"
-        @focus="${this.cancelPendingUpdateEvent}"
+        @focus="${this.handleInputFocus}"
         @blur="${this.handleMaxDateInput}"
         @keyup="${this.handleKeyUp}"
         .value="${live(this.maxSelectedDate)}"

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -893,6 +893,7 @@ export class HistogramDateRange extends LitElement {
             ${this.minLabelTemplate} ${this.minInputTemplate}
             <div class="dash">-</div>
             ${this.maxLabelTemplate} ${this.maxInputTemplate}
+            <slot name="inputs-right-side"></slot>
           </div>
         </div>
       </div>

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -836,6 +836,7 @@ export class HistogramDateRange extends LitElement {
     #inputs .dash {
       position: relative;
       bottom: -1px;
+      align-self: center; /* Otherwise the dash sticks to the top while the inputs grow */
     }
     input {
       width: ${inputWidth};

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -43,6 +43,7 @@ const selectedRangeColor = css`var(--histogramDateRangeSelectedRangeColor, #DBE0
 const barIncludedFill = css`var(--histogramDateRangeBarIncludedFill, #2C2C2C)`;
 const activityIndicatorColor = css`var(--histogramDateRangeActivityIndicator, #2C2C2C)`;
 const barExcludedFill = css`var(--histogramDateRangeBarExcludedFill, #CCCCCC)`;
+const inputRowMargin = css`var(--histogramDateRangeInputRowMargin, 0)`;
 const inputBorder = css`var(--histogramDateRangeInputBorder, 0.5px solid #2C2C2C)`;
 const inputWidth = css`var(--histogramDateRangeInputWidth, 35px)`;
 const inputFontSize = css`var(--histogramDateRangeInputFontSize, 1.2rem)`;
@@ -832,6 +833,7 @@ export class HistogramDateRange extends LitElement {
     #inputs {
       display: flex;
       justify-content: center;
+      margin: ${inputRowMargin};
     }
     #inputs .dash {
       position: relative;

--- a/test/histogram-date-range.test.ts
+++ b/test/histogram-date-range.test.ts
@@ -104,7 +104,7 @@ describe('HistogramDateRange', () => {
     expect(maxDateInput.value).to.eq('12/31/2199');
   });
 
-  it('when updateWhenFocused option is true, updates are fired upon changing input focus', async () => {
+  it('when updateWhileFocused option is true, updates are fired upon changing input focus', async () => {
     const el = await createCustomElementInHTMLContainer();
     el.updateWhileFocused = true;
     await el.updateComplete;
@@ -153,7 +153,7 @@ describe('HistogramDateRange', () => {
     expect(el.maxSelectedDate).to.eq('3/12/1975');
   });
 
-  it('when updateWhenFocused option is false (default), updates are not fired while one of the inputs remains focused', async () => {
+  it('when updateWhileFocused option is false (default), updates are not fired while one of the inputs remains focused', async () => {
     const el = await createCustomElementInHTMLContainer();
 
     let updateEventFired = false;

--- a/test/histogram-date-range.test.ts
+++ b/test/histogram-date-range.test.ts
@@ -104,6 +104,95 @@ describe('HistogramDateRange', () => {
     expect(maxDateInput.value).to.eq('12/31/2199');
   });
 
+  it('when updateWhenFocused option is true, updates are fired upon changing input focus', async () => {
+    const el = await createCustomElementInHTMLContainer();
+    el.updateWhileFocused = true;
+    await el.updateComplete;
+
+    let updateEventFired = false;
+    el.addEventListener(
+      'histogramDateRangeUpdated',
+      () => (updateEventFired = true)
+    );
+
+    /* -------------------------- minimum (left) slider ------------------------- */
+    const minDateInput = el.shadowRoot?.querySelector(
+      '#date-min'
+    ) as HTMLInputElement;
+
+    /* -------------------------- maximum (right) slider ------------------------- */
+    const maxDateInput = el.shadowRoot?.querySelector(
+      '#date-max'
+    ) as HTMLInputElement;
+
+    minDateInput.focus();
+
+    // set valid min date, but don't hit Enter -- just switch focus to the max date input
+    minDateInput.value = '1950';
+    maxDateInput.focus();
+    await el.updateComplete;
+    await aTimeout(0);
+
+    // update event should have fired, setting the minSelectedDate prop & slider position accordingly
+    expect(updateEventFired).to.be.true;
+    expect(Math.floor(el.minSliderX)).to.eq(84);
+    expect(el.minSelectedDate).to.eq('1/1/1950');
+
+    updateEventFired = false;
+    await el.updateComplete;
+
+    // set valid max date, but don't hit Enter -- just switch focus to the min date input
+    maxDateInput.value = '3/12/1975';
+    minDateInput.focus();
+    await el.updateComplete;
+    await aTimeout(0);
+
+    // update event should have fired, setting the maxSelectedDate prop & slider position accordingly
+    expect(updateEventFired).to.be.true;
+    expect(Math.floor(el.maxSliderX)).to.eq(121);
+    expect(el.maxSelectedDate).to.eq('3/12/1975');
+  });
+
+  it('when updateWhenFocused option is false (default), updates are not fired while one of the inputs remains focused', async () => {
+    const el = await createCustomElementInHTMLContainer();
+
+    let updateEventFired = false;
+    el.addEventListener(
+      'histogramDateRangeUpdated',
+      () => (updateEventFired = true)
+    );
+
+    /* -------------------------- minimum (left) slider ------------------------- */
+    const minDateInput = el.shadowRoot?.querySelector(
+      '#date-min'
+    ) as HTMLInputElement;
+
+    /* -------------------------- maximum (right) slider ------------------------- */
+    const maxDateInput = el.shadowRoot?.querySelector(
+      '#date-max'
+    ) as HTMLInputElement;
+
+    minDateInput.focus();
+
+    // set valid min date, but don't hit Enter -- just switch focus to the max date input
+    minDateInput.value = '1950';
+    maxDateInput.focus();
+    await el.updateComplete;
+    await aTimeout(0);
+
+    // update event should NOT have fired, because focus remains within the inputs
+    expect(updateEventFired).to.be.false;
+
+    // set valid max date, but don't hit Enter -- just switch focus to the min date input
+    maxDateInput.value = '3/12/1975';
+    minDateInput.focus();
+    await el.updateComplete;
+    await aTimeout(0);
+
+    // update event should NOT have fired, because focus remains within the inputs
+    expect(updateEventFired).to.be.false;
+  });
+
   it('handles invalid date inputs', async () => {
     const el = await createCustomElementInHTMLContainer();
 


### PR DESCRIPTION
To enable custom buttons to be added in the region to the right of the date input fields, this PR adds a named slot there. This is currently to enable a use case where the date picker is displayed in a large modal dialog, which needs to place an "Apply date range" button in this location.

A new CSS var `--histogramDateRangeInputRowMargin` is also exposed, to allow customizing the margins around the row of inputs (including the new slot).