### PR TITLE
WEBDEV-5981 Updating the width/height properties should re-render the svg

### DIFF
--- a/docs/dist/src/histogram-date-range.js
+++ b/docs/dist/src/histogram-date-range.js
@@ -107,7 +107,7 @@ export let HistogramDateRange = class extends LitElement {
     super.disconnectedCallback();
   }
   updated(changedProps) {
-    if (changedProps.has("bins") || changedProps.has("minDate") || changedProps.has("maxDate") || changedProps.has("minSelectedDate") || changedProps.has("maxSelectedDate")) {
+    if (changedProps.has("bins") || changedProps.has("minDate") || changedProps.has("maxDate") || changedProps.has("minSelectedDate") || changedProps.has("maxSelectedDate") || changedProps.has("width") || changedProps.has("height")) {
       this.handleDataUpdate();
     }
   }

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -122,7 +122,9 @@ export class HistogramDateRange extends LitElement {
       changedProps.has('minDate') ||
       changedProps.has('maxDate') ||
       changedProps.has('minSelectedDate') ||
-      changedProps.has('maxSelectedDate')
+      changedProps.has('maxSelectedDate') ||
+      changedProps.has('width') ||
+      changedProps.has('height')
     ) {
       this.handleDataUpdate();
     }


### PR DESCRIPTION
Currently, if the component's `width` or `height` properties are changed, the outer container has its size updated accordingly but the size of its bars does not change. As a result, some histogram bars may be hidden and inaccessible after the resize, or may only take up part of the available space.

This PR ensures that updates to `width` and `height` trigger a full update to the svg and its histogram bars, so that the rendered result looks as expected and does not clip outside its new bounds.