### PR TITLE
Hard peg dayjs dependency to 1.11.10

### DIFF
--- a/docs/dist/src/histogram-date-range.js
+++ b/docs/dist/src/histogram-date-range.js
@@ -19,7 +19,7 @@ import {
 import {property, state, customElement} from "../../_snowpack/pkg/lit/decorators.js";
 import {live} from "../../_snowpack/pkg/lit/directives/live.js";
 import "../../_snowpack/pkg/@internetarchive/ia-activity-indicator/ia-activity-indicator.js";
-import dayjs from "https://esm.archive.org/dayjs@^1.10.7";
+import dayjs from "https://esm.archive.org/dayjs@1.11.10";
 import customParseFormat from "https://esm.archive.org/dayjs@1.9.4/esm/plugin/customParseFormat";
 dayjs.extend(customParseFormat);
 const WIDTH = 180;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-activity-indicator": "^0.0.4",
-        "dayjs": "^1.10.7",
+        "dayjs": "1.11.10",
         "lit": "^2.2.7"
       },
       "devDependencies": {
@@ -3567,9 +3567,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debounce": {
       "version": "1.2.0",
@@ -13481,9 +13481,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
-      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "debounce": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@internetarchive/ia-activity-indicator": "^0.0.4",
-    "dayjs": "^1.10.7",
+    "dayjs": "1.11.10",
     "lit": "^2.2.7"
   },
   "devDependencies": {

--- a/src/histogram-date-range.ts
+++ b/src/histogram-date-range.ts
@@ -14,7 +14,7 @@ import '@internetarchive/ia-activity-indicator/ia-activity-indicator';
 
 /* eslint-disable-next-line */
 /* @ts-ignore Import module -- JS, so no types */
-import dayjs from 'https://esm.archive.org/dayjs@^1.10.7';
+import dayjs from 'https://esm.archive.org/dayjs@1.11.10';
 /* eslint-disable-next-line */
 /* @ts-ignore Import module -- JS, so no types */
 import customParseFormat from 'https://esm.archive.org/dayjs@1.9.4/esm/plugin/customParseFormat';


### PR DESCRIPTION
To ensure consistent builds in the presence of our dayjs esm import workaround, this PR pegs the dayjs version to exactly 1.11.10 for the time being. Further work will explore the possibility of weaning off dayjs entirely -- otherwise, we will manually upgrade this version when necessary rather than relying on caret versioning.