### PR TITLE
WEBDEV-7756 Export bar scaling types from package

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,7 @@
 export {
   HistogramDateRange,
   BinSnappingInterval,
+  BarScalingPreset,
+  BarScalingFunction,
+  BarScalingOption,
 } from './src/histogram-date-range';


### PR DESCRIPTION
#34 introduced the `barScaling` option to customize how bin values translate into bar heights. This PR just exports the associated types so that consumers can make use of them.