### PR TITLE
v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/histogram-date-range",
-  "version": "1.3.2",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/histogram-date-range",
-      "version": "1.3.2",
+      "version": "1.5.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-activity-indicator": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/histogram-date-range",
-  "version": "1.3.2",
+  "version": "1.5.0",
   "description": "Internet Archive histogram date range picker",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",


### PR DESCRIPTION
Version includes new properties allowing more customization of the histogram display:
- `barScaling` property to adjust how bin values are scaled when determining bar heights
- `tooltipLabel` property to customize how bin values are labeled on tooltips

To better account for small bars which may be difficult to hover directly, tooltips now appear when hovering anywhere above a bar in addition to the bar itself.